### PR TITLE
Remove NIP-05 field from profile creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nosdav",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "Create NosDav profiles and apps with ease",
   "bin": {
     "create-nosdav": "./bin/create-nosdav.js"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -28,11 +28,6 @@ async function initProfile(name, options) {
       name: 'about',
       message: 'About (brief description):',
       default: 'NosDav user profile'
-    },
-    {
-      type: 'input',
-      name: 'nip05',
-      message: 'NIP-05 identifier (optional):'
     }
   ]);
 
@@ -50,7 +45,7 @@ async function initProfile(name, options) {
       name: answers.displayName,
       picture: `https://nosdav.net/${profileId}/public/images/thumb.png`,
       about: answers.about,
-      nip05: answers.nip05 || '',
+      nip05: '',
       subkeys: '',
       publicTypeIndex: './settings/publicTypeIndex.json',
       storage: [`https://nosdav.net/${profileId}/`],


### PR DESCRIPTION
Simplifies the profile creation experience by removing the optional NIP-05 field.

## Changes
- ✅ Remove NIP-05 prompt from profile initialization
- ✅ Set empty nip05 field in generated index.json
- ✅ Bump version to 0.0.4

## Benefits
- Cleaner, simpler onboarding flow
- Reduces cognitive overhead for new users
- Focuses on core functionality
- Users can still manually add NIP-05 to index.json later

## Testing
- Profile creation no longer prompts for NIP-05
- Generated profiles have empty nip05 field
- All other functionality remains unchanged

Fixes #3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove NIP-05 field from profile creation, simplifying the process and updating version to 0.0.4.
> 
>   - **Behavior**:
>     - Remove NIP-05 prompt from `initProfile` in `init.js`.
>     - Set `nip05` to an empty string in `index.json`.
>   - **Version**:
>     - Update version to 0.0.4 in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nosdav%2Fcreate-nosdav&utm_source=github&utm_medium=referral)<sup> for 304bd7da533e0b3996e7c399be1811dc52d35a51. You can [customize](https://app.ellipsis.dev/nosdav/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->